### PR TITLE
Update next visit date to default to the visit date + 30 days OHRI-1258

### DIFF
--- a/distro/configuration/ampathforms/pmtct_antenatal_v1.0.json
+++ b/distro/configuration/ampathforms/pmtct_antenatal_v1.0.json
@@ -931,7 +931,10 @@
               "id": "next_visit_date",
               "questionOptions": {
                 "concept": "5096AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
-                "rendering": "date"
+                "rendering": "date",
+                "calculate": {
+                  "calculateExpression": "addDaysToDate(useFieldValue('visit_date'), 30)"
+                }
               },
               "behaviours":[
                 {


### PR DESCRIPTION
hi @pirupius I made the following changes to the form Engine if you get chance kindly look at it


`  addDaysToDate = (date, days) => {
    const newDate = new Date(date); 
    dayjs(newDate).format('DD/MM/YYYY')
    newDate.setDate(newDate.getDate() + days); 
    if(isNaN(newDate.getTime())){
      return;
    }
    return newDate;// Return the new date
  };`
common-expression-helper.ts file
