### PR TITLE
change the infant pnc uuid as a new form was published

### DIFF
--- a/frontend/ohri-config.json
+++ b/frontend/ohri-config.json
@@ -141,7 +141,7 @@
       "antenatalFormUuid": "5255a535-2acb-3f44-bd0a-3f80595dece1",
       "labourAndDeliveryFormUuid": "60252155-f40d-3084-9d8e-5b7c8fafc68a",
       "motherPostnatalFormUuid": "2105c8ae-1935-375c-a7cc-e2ca04c8f6be",
-      "infantPostnatalFormUuid": "120048e5-4122-3c6d-8f77-c79e75b7b3fc"
+      "infantPostnatalFormUuid": "0dd206d0-6744-3684-97fc-7be3079ce4b9"
     },
     "encounterTypes": {
       "antenatalEncounterType": "2549af50-75c8-4aeb-87ca-4bb2cef6c69a",


### PR DESCRIPTION
change the infant pnc uuid as a new form was published. This is to ensure the infant pnc form open
![image](https://github.com/user-attachments/assets/1e3a2250-a092-4dd8-abc0-f9b39ac0bfe2)
