### PR TITLE
OHRI-2276: Five (5) digit facility code in ART unique number implemented in PTra…

### DIFF
--- a/distro/configuration/ampathforms/pmtct_antenatal_v1.0.json
+++ b/distro/configuration/ampathforms/pmtct_antenatal_v1.0.json
@@ -628,7 +628,7 @@
                       "type": "js_expression",
                       "failsWhenExpression": "!/^([0-9]{3}[0-9]{9}|[0-9]{5}[0-9]{9})$/.test(myValue)",
                       "message": "Invalid art number, provide an art number that follows this format: 3-5 digits for the facility code, followed by the month and year (MMYY), and ending with 5 digits for the sequential number"
-                    }                                       
+                    }                                    
                   ]
                 }
               ]

--- a/distro/configuration/ampathforms/pmtct_antenatal_v1.0.json
+++ b/distro/configuration/ampathforms/pmtct_antenatal_v1.0.json
@@ -628,7 +628,7 @@
                       "type": "js_expression",
                       "failsWhenExpression": "!/^([0-9]{3}[0-9]{9}|[0-9]{5}[0-9]{9})$/.test(myValue)",
                       "message": "Invalid art number, provide an art number that follows this format: 3-5 digits for the facility code, followed by the month and year (MMYY), and ending with 5 digits for the sequential number"
-                    }                                    
+                    }
                   ]
                 }
               ]

--- a/distro/configuration/ampathforms/pmtct_antenatal_v1.0.json
+++ b/distro/configuration/ampathforms/pmtct_antenatal_v1.0.json
@@ -626,7 +626,7 @@
                   "validators": [
                     {
                       "type": "js_expression",
-                      "failsWhenExpression": "!/^([0-9]{3}[0-9]{9}|[0-9]{4}[0-9]{9}|[0-9]{5}[0-9]{9})$/.test(myValue)",
+                      "failsWhenExpression": "!/^([0-9]{3}[0-9]{9}|[0-9]{5}[0-9]{9})$/.test(myValue)",
                       "message": "Invalid art number, provide an art number that follows this format: 3-5 digits for the facility code, followed by the month and year (MMYY), and ending with 5 digits for the sequential number"
                     }                                       
                   ]

--- a/distro/configuration/ampathforms/pmtct_antenatal_v1.0.json
+++ b/distro/configuration/ampathforms/pmtct_antenatal_v1.0.json
@@ -626,9 +626,9 @@
                   "validators": [
                     {
                       "type": "js_expression",
-                      "failsWhenExpression": "!/^[0-9]{3,5}[0,1][0-9]{8}$$/.test(myValue)",
+                      "failsWhenExpression": "!/^([0-9]{3}[0-9]{9}|[0-9]{4}[0-9]{9}|[0-9]{5}[0-9]{9})$/.test(myValue)",
                       "message": "Invalid art number, provide an art number that follows this format: 3-5 digits for the facility code, followed by the month and year (MMYY), and ending with 5 digits for the sequential number"
-                    }
+                    }                                       
                   ]
                 }
               ]

--- a/distro/configuration/ampathforms/pmtct_labour_and_delivery_v1.0.json
+++ b/distro/configuration/ampathforms/pmtct_labour_and_delivery_v1.0.json
@@ -752,7 +752,7 @@
                   "validators": [
                     {
                       "type": "js_expression",
-                      "failsWhenExpression": "!/^[0-9]{3,5}[0,1][0-9]{8}$$/.test(myValue)",
+                      "failsWhenExpression": "!/^([0-9]{3}[0-9]{9}|[0-9]{4}[0-9]{9}|[0-9]{5}[0-9]{9})$/.test(myValue)",
                       "message": "Invalid art number, provide an art number that follows this format: 3-5 digits for the facility code, followed by the month and year (MMYY), and ending with 5 digits for the sequential number"
                     }
                   ]

--- a/distro/configuration/ampathforms/pmtct_labour_and_delivery_v1.0.json
+++ b/distro/configuration/ampathforms/pmtct_labour_and_delivery_v1.0.json
@@ -752,7 +752,7 @@
                   "validators": [
                     {
                       "type": "js_expression",
-                      "failsWhenExpression": "!/^([0-9]{3}[0-9]{9}|[0-9]{4}[0-9]{9}|[0-9]{5}[0-9]{9})$/.test(myValue)",
+                      "failsWhenExpression": "!/^([0-9]{3}[0-9]{9}|[0-9]{5}[0-9]{9})$/.test(myValue)",
                       "message": "Invalid art number, provide an art number that follows this format: 3-5 digits for the facility code, followed by the month and year (MMYY), and ending with 5 digits for the sequential number"
                     }
                   ]

--- a/distro/configuration/ampathforms/pmtct_mother_postnatal_v1.0.json
+++ b/distro/configuration/ampathforms/pmtct_mother_postnatal_v1.0.json
@@ -477,7 +477,7 @@
                   "validators": [
                     {
                       "type": "js_expression",
-                      "failsWhenExpression": "!/^[0-9]{3,5}[0,1][0-9]{8}$$/.test(myValue)",
+                     "failsWhenExpression": "!/^([0-9]{3}[0-9]{9}|[0-9]{4}[0-9]{9}|[0-9]{5}[0-9]{9})$/.test(myValue)",
                       "message": "Invalid art number, provide an art number that follows this format: 3-5 digits for the facility code, followed by the month and year (MMYY), and ending with 5 digits for the sequential number"
                     }
                   ]

--- a/distro/configuration/ampathforms/pmtct_mother_postnatal_v1.0.json
+++ b/distro/configuration/ampathforms/pmtct_mother_postnatal_v1.0.json
@@ -477,7 +477,7 @@
                   "validators": [
                     {
                       "type": "js_expression",
-                     "failsWhenExpression": "!/^([0-9]{3}[0-9]{9}|[0-9]{5}[0-9]{9})$/.test(myValue)",
+                      "failsWhenExpression": "!/^([0-9]{3}[0-9]{9}|[0-9]{5}[0-9]{9})$/.test(myValue)",
                       "message": "Invalid art number, provide an art number that follows this format: 3-5 digits for the facility code, followed by the month and year (MMYY), and ending with 5 digits for the sequential number"
                     }
                   ]

--- a/distro/configuration/ampathforms/pmtct_mother_postnatal_v1.0.json
+++ b/distro/configuration/ampathforms/pmtct_mother_postnatal_v1.0.json
@@ -477,7 +477,7 @@
                   "validators": [
                     {
                       "type": "js_expression",
-                     "failsWhenExpression": "!/^([0-9]{3}[0-9]{9}|[0-9]{4}[0-9]{9}|[0-9]{5}[0-9]{9})$/.test(myValue)",
+                     "failsWhenExpression": "!/^([0-9]{3}[0-9]{9}|[0-9]{5}[0-9]{9})$/.test(myValue)",
                       "message": "Invalid art number, provide an art number that follows this format: 3-5 digits for the facility code, followed by the month and year (MMYY), and ending with 5 digits for the sequential number"
                     }
                   ]


### PR DESCRIPTION
Five (5) digit facility code in ART unique number implemented in PTracker

The ART Unique number should have the  following;
3-5 digits for the facility code.
2 digits for the month.
2 digits for the year.
5 digits for the extra numbers.
The total length should be 12 or 14 digits.

for example the number can be 123012488888 or 12345012488888
(123, 12345 is the facility code as it can be 3 or 5 digits)

[Screencast from 2024-07-22 12-46-23.webm](https://github.com/user-attachments/assets/9cccb0a0-f69f-4787-a3d8-8fdf192fec74)

