### PR TITLE
OHRI-2304: failling expression and error rendering field causing L&d  form not to save

### DIFF
--- a/distro/configuration/ampathforms/pmtct_labour_and_delivery_v1.0.json
+++ b/distro/configuration/ampathforms/pmtct_labour_and_delivery_v1.0.json
@@ -767,7 +767,7 @@
                 "concept": "159599AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "rendering": "date",
                 "calculate": {
-                  "calculateExpression": "art_initiation == '160119AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' ? myValue = formatDate('latest_anc_art_start_date') : ''"
+                  "calculateExpression": "art_initiation === '160119AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' && !isEmpty(latest_anc_art_start_date) ? formatDate(latest_anc_art_start_date) : ''"
                 }
               },
               "behaviours": [

--- a/distro/configuration/ampathforms/pmtct_labour_and_delivery_v1.0.json
+++ b/distro/configuration/ampathforms/pmtct_labour_and_delivery_v1.0.json
@@ -747,7 +747,7 @@
                   "required": "true",
                   "unspecified": "true",
                   "hide": {
-                    "hideWhenExpression": "!isEmpty(latest_art_number) ? true : isEmpty(latest_art_number) && latest_art_initiation == '160119AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || latest_art_initiation == '160120AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' ? false : art_initiation !== '160119AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' && art_initiation !== '160120AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || anc_hiv_test_status !== '8b8951a8-e8d6-40ca-ad70-89e8f8f71fa8' && anc_hiv_test_status !== '703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' && anc_hiv_test_status !== '1402AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' && anc_hiv_test_status !== '664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || hiv_test_status !== '138571AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
+                    "hideWhenExpression": "!isEmpty(latest_art_number) ? true : isEmpty(latest_art_number) && latest_art_initiation == '160119AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || latest_art_initiation == '160120AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' ? false : art_initiation !== '160119AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' && art_initiation !== '160120AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' || anc_hiv_test_status !== '8b8951a8-e8d6-40ca-ad70-89e8f8f71fa8' && anc_hiv_test_status !== '703AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' && anc_hiv_test_status !== '1402AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' && anc_hiv_test_status !== '664AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'"
                   },
                   "validators": [
                     {


### PR DESCRIPTION
This PR resolves two errors;
1. The `hiv_test_status` is not defined in the form. 

![image](https://github.com/user-attachments/assets/4c4b0138-06fc-43f6-b607-8add0d7644a3)

2. the `Error rendering field Invalid time value`  when the `Already on ART` is selected...  I added  a validation that
ensures that formatDate(latest_anc_art_start_date) is only executed if `latest_anc_art_start_date` is present . 

If `latest_anc_art_start_date` is empty, it will return an empty string. This prevents formatting errors 



