### PR TITLE
Fix calculation of next visit date to be performed correctly

### DIFF
--- a/distro/configuration/ampathforms/pmtct_antenatal_v1.0.json
+++ b/distro/configuration/ampathforms/pmtct_antenatal_v1.0.json
@@ -1105,7 +1105,7 @@
                 "concept": "5096AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "rendering": "date",
                 "calculate": {
-                  "calculateExpression": "visit_date !== '' ? addDaysToDate(useFieldValue('visit_date'), 30) : ''"
+                  "calculateExpression": "useFieldValue('visit_date') ? addDaysToDate(useFieldValue('visit_date'), 30) : ''"
                 }
               },
               "behaviours": [

--- a/distro/configuration/ampathforms/pmtct_infant_postnatal_v1.0.json
+++ b/distro/configuration/ampathforms/pmtct_infant_postnatal_v1.0.json
@@ -844,7 +844,7 @@
                 "concept": "5096AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "rendering": "date",
                 "calculate": {
-                  "calculateExpression": "visit_date !== '' ? addDaysToDate(useFieldValue('visit_date'), 30) : ''"
+                  "calculateExpression": "useFieldValue('visit_date') ? addDaysToDate(useFieldValue('visit_date'), 30) : ''"
                 }
               },
               "behaviours": [

--- a/distro/configuration/ampathforms/pmtct_mother_postnatal_v1.0.json
+++ b/distro/configuration/ampathforms/pmtct_mother_postnatal_v1.0.json
@@ -685,7 +685,7 @@
                 "concept": "5096AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
                 "rendering": "date",
                 "calculate": {
-                  "calculateExpression": "visit_date !== '' ? addDaysToDate(useFieldValue('visit_date'), 30) : ''"
+                  "calculateExpression": "useFieldValue('visit_date') ? addDaysToDate(useFieldValue('visit_date'), 30) : ''"
                 }
               },
               "behaviours": [


### PR DESCRIPTION
This fix changes to using useFieldValue('visit_date') ? that is more robust and reliable because it checks for any falsy value (including null, undefined, and empty strings). It ensures that the calculation only runs when there's a valid date value to work with as compared to the original approach that only checks for empty strings and might miss cases where the visit_date is absent or invalid in other ways, which could lead to unintended behavior as in screenshot one.

Screenshot with original calculate expression
![image](https://github.com/user-attachments/assets/7c057c27-f5d1-401d-a8ee-8d0df8162236)

Screenshot with fix
![image](https://github.com/user-attachments/assets/572bef65-507b-4511-9a3a-e9af29e4fab6)

https://github.com/user-attachments/assets/2aa15e30-fcbe-4c59-bb57-bba9f3ad7d4c


